### PR TITLE
BUGFIX: Limit docker privilege to only /dev/vchiq.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or, get it from Docker Hub
 
 To use simply execute `ffmpeg`.
 
-    docker run -it --rm --privileged adilinden/rpi-ffmpeg ffmpeg \
+    docker run -it --rm --device=/dev/vchiq adilinden/rpi-ffmpeg ffmpeg \
 	    -re -f mjpeg -framerate 5 -i http://<IP of OctoPi>:8080/?action=stream \
 	    -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -acodec aac -ab 128k \
 	    -strict experimental -vcodec h264 -pix_fmt yuv420p -g 10 -vb 700k -framerate 5 \


### PR DESCRIPTION
Resolves issue #1 